### PR TITLE
Fix language support on different clang versions

### DIFF
--- a/.github/workflows/testimage.yml
+++ b/.github/workflows/testimage.yml
@@ -26,6 +26,12 @@ jobs:
         with:
           source-ref: testdata
           target-ref: master
+      - name: test json is skipped
+        uses: wolletd/clang-format-checker@test
+        with:
+          source-ref: testdata
+          target-ref: master
+          clang-version: 12
       - name: test with format error
         uses: wolletd/clang-format-checker@test
         with:

--- a/0001-remove-json-csharp-support.patch
+++ b/0001-remove-json-csharp-support.patch
@@ -1,0 +1,14 @@
+--- a/git-clang-format-13
++++ b/git-clang-format-13
+@@ -84,8 +84,6 @@ def main():
+       'java',  # Java
+       'js',  # JavaScript
+       'ts',  # TypeScript
+-      'cs',  # C Sharp
+-      'json',  # Json
+       ])
+ 
+   p = argparse.ArgumentParser(
+-- 
+2.33.1
+

--- a/0001-remove-json-support.patch
+++ b/0001-remove-json-support.patch
@@ -1,0 +1,13 @@
+--- a/git-clang-format-13
++++ b/git-clang-format-13
+@@ -85,7 +85,6 @@ def main():
+       'js',  # JavaScript
+       'ts',  # TypeScript
+       'cs',  # C Sharp
+-      'json',  # Json
+       ])
+ 
+   p = argparse.ArgumentParser(
+-- 
+2.33.1
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk --no-cache add git python3 && ln -s python3 /usr/bin/python
+RUN apk --no-cache add git python3 patch && ln -s python3 /usr/bin/python
 
 ARG GH_REPO="muttleyxd/clang-tools-static-binaries"
 ARG GH_RELEASE="master-f3a37dd2"
@@ -22,8 +22,15 @@ ADD ${GH_URL}/clang-format-3.9_linux-amd64  \
     check-format.sh                         \
     set-clang-version                       \
     clang-format_linux.sha512sums           \
+    git-clang-format-13                     \
+    0001-remove-json-support.patch          \
+    0001-remove-json-csharp-support.patch   \
     /usr/local/bin/
-ADD git-clang-format-13 /usr/local/bin/git-clang-format
+
+RUN cd /usr/local/bin && \
+    patch -o git-clang-format-12 <0001-remove-json-support.patch && \
+    patch -o git-clang-format-8 <0001-remove-json-csharp-support.patch && \
+    chmod +x git-clang-format-12 git-clang-format-8
 
 RUN cd /usr/local/bin && sha512sum -c clang-format_linux.sha512sums && \
     chmod +x /usr/local/bin/clang-format-* && set-clang-version 13

--- a/action.yml
+++ b/action.yml
@@ -13,9 +13,8 @@ inputs:
     required: false
     default: HEAD
   clang-version:
-    description: 'The version of clang-format to use (3.9 to 12)'
+    description: 'The version of clang-format to use (default: latest)'
     required: false
-    default: 12
   fetch-depth:
     description: 'Fetch depth for git (default: 50)'
     required: false

--- a/set-clang-version
+++ b/set-clang-version
@@ -1,8 +1,20 @@
 #!/bin/sh
 
 [ -n "$1" ] || { echo "Error: Missing argument" >&2; exit 1; }
+ver="$1"
 
-clang_format_bin="/usr/local/bin/clang-format-$1_linux-amd64"
+clang_format_bin="/usr/local/bin/clang-format-${ver}_linux-amd64"
 [ -f "$clang_format_bin" ] || { echo "Error: File $clang_format_bin not found" >&2; exit 1; }
 
 ln -sf "$clang_format_bin" /usr/bin/clang-format
+
+ver="${ver%%.*}"
+if [ $ver -le 8 ]; then
+    git_cf_ver=8
+elif [ $ver -le 12 ]; then
+    git_cf_ver=12
+else
+    git_cf_ver=13
+fi
+
+ln -sf "/usr/local/bin/git-clang-format-${git_cf_ver}" /usr/bin/git-clang-format


### PR DESCRIPTION
Closes #6. In the PR yesterday, I actually missed removing the `default: 12` from `action.yml`, which made the GH action still use version 12.