### PR TITLE
Add a docker wrapper to run clang-format-checker locally

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -26,7 +26,7 @@ jobs:
         run: docker push wolletd/clang-format:latest
       - name: Push the rooted image
         run: docker push wolletd/clang-format:root
-  tests:
+  tests-standalone:
     runs-on: ubuntu-latest
     needs: docker
     steps:
@@ -94,3 +94,19 @@ jobs:
       - name: check for expected failures
         if: steps.fail1.outcome == 'success' || steps.fail2.outcome == 'success'
         run: exit 1
+  tests-wrapper:
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: fetch required refs
+        run: git fetch --depth=50 origin master:master tag testdata tag testdata2
+      - name: test with no error
+        run: ./clang-format-checker master testdata
+      - name: test json is skipped
+        run: ./clang-format-checker -v12 master testdata
+      - name: test with git error
+        run: '! ./clang-format-checker nonexistent testdata'
+      - name: test with format error
+        run: '! ./clang-format-checker master testdata2'

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -28,6 +28,12 @@ jobs:
         with:
           source-ref: testdata
           target-ref: master
+      - name: test json is skipped
+        uses: wolletd/clang-format-checker@master
+        with:
+          source-ref: testdata
+          target-ref: master
+          clang-version: 12
       - name: test with format error
         uses: wolletd/clang-format-checker@master
         with:
@@ -42,6 +48,42 @@ jobs:
           target-ref: nonexistent
         continue-on-error: true
         id: fail2
+      - name: check for expected failures
+        if: steps.fail1.outcome == 'success' || steps.fail2.outcome == 'success'
+        run: exit 1
+  tests-checkout:
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - name: checkout testdata
+        uses: actions/checkout@v2
+        with:
+          ref: testdata
+      - name: test with no error
+        uses: wolletd/clang-format-checker@master
+        with:
+          target-ref: master
+      - name: test json is skipped
+        uses: wolletd/clang-format-checker@master
+        with:
+          target-ref: master
+          clang-version: 12
+      - name: test with git error
+        uses: wolletd/clang-format-checker@master
+        with:
+          target-ref: nonexistent
+        continue-on-error: true
+        id: fail2
+      - name: checkout testdata2
+        uses: actions/checkout@v2
+        with:
+          ref: testdata2
+      - name: test with format error
+        uses: wolletd/clang-format-checker@master
+        with:
+          target-ref: master
+        continue-on-error: true
+        id: fail1
       - name: check for expected failures
         if: steps.fail1.outcome == 'success' || steps.fail2.outcome == 'success'
         run: exit 1

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ master ]
 
+env:
+  SHOW_SKIPPED: 1
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,7 +14,9 @@ jobs:
       - name: Pull repository
         uses: actions/checkout@v2
       - name: Build the image
-        run: docker build . --tag wolletd/clang-format:latest
+        run: docker build . --build-arg UID=$(id -u) --tag wolletd/clang-format:latest
+      - name: Build the rooted image
+        run: docker build . --target root --build-arg UID=$(id -u) --tag wolletd/clang-format:root
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -22,6 +24,8 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push the image
         run: docker push wolletd/clang-format:latest
+      - name: Push the rooted image
+        run: docker push wolletd/clang-format:root
   tests:
     runs-on: ubuntu-latest
     needs: docker

--- a/.github/workflows/testimage.yml
+++ b/.github/workflows/testimage.yml
@@ -2,6 +2,9 @@ name: Build Test Image
 
 on: [ pull_request ]
 
+env:
+  SHOW_SKIPPED: 1
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/testimage.yml
+++ b/.github/workflows/testimage.yml
@@ -49,3 +49,39 @@ jobs:
       - name: check for expected failures
         if: steps.fail1.outcome == 'success' || steps.fail2.outcome == 'success'
         run: exit 1
+  tests-checkout:
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - name: checkout testdata
+        uses: actions/checkout@v2
+        with:
+          ref: testdata
+      - name: test with no error
+        uses: wolletd/clang-format-checker@test
+        with:
+          target-ref: master
+      - name: test json is skipped
+        uses: wolletd/clang-format-checker@test
+        with:
+          target-ref: master
+          clang-version: 12
+      - name: test with git error
+        uses: wolletd/clang-format-checker@test
+        with:
+          target-ref: nonexistent
+        continue-on-error: true
+        id: fail2
+      - name: checkout testdata2
+        uses: actions/checkout@v2
+        with:
+          ref: testdata2
+      - name: test with format error
+        uses: wolletd/clang-format-checker@test
+        with:
+          target-ref: master
+        continue-on-error: true
+        id: fail1
+      - name: check for expected failures
+        if: steps.fail1.outcome == 'success' || steps.fail2.outcome == 'success'
+        run: exit 1

--- a/.github/workflows/testimage.yml
+++ b/.github/workflows/testimage.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Pull repository
         uses: actions/checkout@v2
       - name: Build the image
-        run: docker build . --tag wolletd/clang-format:test
+        run: docker build . --build-arg UID=$(id -u) --tag wolletd/clang-format:test
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/testimage.yml
+++ b/.github/workflows/testimage.yml
@@ -20,7 +20,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push the image
         run: docker push wolletd/clang-format:test
-  tests:
+  tests-standalone:
     runs-on: ubuntu-latest
     needs: docker
     steps:
@@ -88,3 +88,21 @@ jobs:
       - name: check for expected failures
         if: steps.fail1.outcome == 'success' || steps.fail2.outcome == 'success'
         run: exit 1
+  tests-wrapper:
+    runs-on: ubuntu-latest
+    needs: docker
+    env:
+      CFC_DOCKER_IMAGE: wolletd/clang-format:test
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: fetch required refs
+        run: git fetch --depth=50 origin master:master tag testdata tag testdata2
+      - name: test with no error
+        run: ./clang-format-checker master testdata
+      - name: test json is skipped
+        run: ./clang-format-checker -v12 master testdata
+      - name: test with git error
+        run: '! ./clang-format-checker nonexistent testdata'
+      - name: test with format error
+        run: '! ./clang-format-checker master testdata2'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ script in GitLab CI scripts). No checkout before running this action is required
 Uses static clang-format binaries from
 [muttleyxd/clang-tools-static-binaries](https://github.com/muttleyxd/clang-tools-static-binaries).
 
+The container can also be used locally via the `clang-format-checker` script.
+
 ## Usage
+
+### As GitHub action
 
 ```yaml
 jobs:
@@ -28,6 +32,16 @@ jobs:
           fetch-depth: 80       # optional, rarely needed, default: 50
           source-ref: develop   # optional, almost never needed, default: HEAD
 ```
+
+### Local
+
+Download the `clang-format-checker` script (or clone the repository if you want to build the
+container yourself) and execute it with arguments `[-v VER] <target> [source]`.
+
+* the user has to be a member of the `docker` group
+* no fetches are performed
+* run `clang-format-checker --build` to build the image locally (repository required)
+* run `clang-format-checker --pull` to update the image from hub.docker.com
 
 ## Screenshot
 

--- a/action.yml
+++ b/action.yml
@@ -24,8 +24,8 @@ runs:
   using: "docker"
   image: "docker://wolletd/clang-format:latest"
   env:
-    SOURCE_REF: ${{ inputs.source-ref }}
     FETCH_DEPTH: ${{ inputs.fetch-depth }}
     CLANG_VERSION: ${{ inputs.clang-version }}
   args:
     - ${{ inputs.target-ref }}
+    - ${{ inputs.source-ref }}

--- a/check-format.sh
+++ b/check-format.sh
@@ -24,7 +24,9 @@ echo "Checking $(git rev-list --count --reverse "HEAD" "^${revision}") commits s
 for commit in $(git rev-list --reverse "HEAD" "^${revision}"); do
     printf "%s" "${commit}... "
     cfOutput="$(git -c color.ui=always clang-format --diff "${commit}^" "${commit}" -- "$@")";
-    if [ -z "${cfOutput}" ] || [ "${cfOutput}" = "no modified files to format" ]; then
+    if [ "$SHOW_SKIPPED" ] && [ "${cfOutput}" = "no modified files to format" ]; then
+        printf "%b\n" "\e[32mSKIPPED\e[0m"
+    elif [ -z "${cfOutput}" ] || [ "${cfOutput}" = "no modified files to format" ]; then
         printf "%b\n" "\e[32mPASSED\e[0m"
     else
         printf "%b\n" "\e[31;1mFAILED\e[0m"

--- a/check-format.sh
+++ b/check-format.sh
@@ -1,27 +1,36 @@
 #!/bin/sh
 set -e
 
+die() { echo "$@" >&2; exit 1; }
+
 exitCode=0
 
-# Ensure that the current HEAD has some history (by default this is not the case with actions/checkout)
-head_sha=$(git rev-parse --verify HEAD)
-git fetch "--depth=${FETCH_DEPTH:-50}" origin "+${head_sha}"
-
 # Make sure target branch exists
-revisionArg=${1}; shift
-revision=$(git rev-parse --verify "origin/${revisionArg}" 2>/dev/null) || {
-    git fetch "--depth=${FETCH_DEPTH:-50}" origin "${revisionArg}"
-    revision=$(git rev-parse --verify "origin/${revisionArg}" 2>/dev/null || \
-        git rev-parse --verify "${revisionArg}" 2>/dev/null) || {
-            echo "Can't find merge target '${revision}'!" >&2
-            return 1
-        }
-}
+target="$1"; shift
 
-[ -n "${revision}" ] || { echo "Error: Programmer is an idiot" >&2; exit 1; }
-echo "Checking $(git rev-list --count --reverse "HEAD" "^${revision}") commits since revision ${revision}"
+if [ "$CI" ]; then
+    git rev-parse -q --no-revs --verify "origin/${target}" || git fetch origin --depth=1 "${target}"
+    # Ensure that the target revision has some history
+    target_sha=$(git rev-parse --verify "origin/${target}")
+    git fetch -q "--depth=${FETCH_DEPTH:-50}" origin "+${target_sha}"
+else
+    target_sha=$(git rev-parse -q --verify "${target}") || die "fatal: couldn't find ref ${target}"
+fi
 
-for commit in $(git rev-list --reverse "HEAD" "^${revision}"); do
+if [ -z "$1" ] || [ -e "$1" ]; then
+    src=HEAD
+else
+    src="$1"; shift
+fi
+
+# We expect the user or CI (either GitLab or entrypoint.sh) to have taken care of source history
+src_sha=$(git rev-parse -q --verify "${src}") || die "fatal: couldn't find ref ${src}"
+
+echo "Using $(clang-format --version)"
+
+echo "Checking $(git rev-list --count "${src_sha}" "^${target_sha}") commits since revision ${target_sha}"
+
+for commit in $(git rev-list --reverse "${src_sha}" "^${target_sha}"); do
     printf "%s" "${commit}... "
     cfOutput="$(git -c color.ui=always clang-format --diff "${commit}^" "${commit}" -- "$@")";
     if [ "$SHOW_SKIPPED" ] && [ "${cfOutput}" = "no modified files to format" ]; then

--- a/clang-format-checker
+++ b/clang-format-checker
@@ -1,0 +1,68 @@
+#!/bin/bash -e
+
+thisDir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+docker_image="${CFC_DOCKER_IMAGE:-wolletd/clang-format:latest}"
+
+die() { echo "$@" >&2; exit 1; }
+
+usage() {
+    echo -e "Usage: $1 [--pull] [--build] [-v|--version <VER>] <target> [source]\n\n" \
+            "If source is omitted, current HEAD is used.\n\n" \
+            "The --pull and --build flags can be used without target to update the container.\n" \
+            "--build and --pull can be used together to pass --pull to docker build\n\n"
+}
+
+while :; do
+    case "$1" in
+        -v?*|--version=?*)
+            ver="${1#*=}"
+            [ "$ver" != "$1" ] || ver="${1#-v}" ;;
+        -v|--version)
+            [ "$2" ] || die "Error: $1 requires a version"
+            ver="$2"
+            shift ;;
+        --pull)
+            pull=1 ;;
+        --build)
+            build=1 ;;
+        -h|--help)
+            usage "$0"
+            exit 0 ;;
+        --)
+            shift; break ;;
+        -?*)
+            echo "Warning: ignoring option $1" ;;
+        *)
+            break
+    esac
+    shift
+done
+
+if [ -n "$ver" ]; then
+    [[ ${ver%%.*} -gt 0 ]] || die "Error: invalid clang version \"$CLANG_VERSION\""
+    CLANG_VERSION="$ver"
+fi
+
+export CLANG_VERSION
+
+if [ "$build" ]; then
+    [ -f "$thisDir/Dockerfile" ] || die "Error: script has to be in project directory to use --build"
+    docker build ${pull:+--pull} -t "$docker_image" "$thisDir"
+    # exit without warning when no other args are present
+    [ $# -gt 0 ] || exit 0
+elif [ "$pull" ]; then
+    docker pull "$docker_image"
+    # exit without warning when no other args are present
+    [ $# -gt 0 ] || exit 0
+fi
+
+[ -n "$1" ] || die "Error: missing target ref (-h for usage)"
+
+docker run                  \
+    --rm                    \
+    -v "${PWD}:/workdir"    \
+    -e CLANG_VERSION        \
+    -e SHOW_SKIPPED         \
+    --workdir "/workdir"    \
+    -u "$(id -u):$(id -g)"  \
+    "${docker_image}" "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,24 +7,34 @@ if [ -n "$GITLAB_CI" ]; then
     exit $?
 fi
 
+die() { echo "$@" >&2; exit 1; }
+
+target="$1"; shift || die "error: missing target ref"
+if [ -z "$1" ] || [ -e "$1" ]; then
+    ref=HEAD
+else
+    ref="$1"; shift
+fi
+
 # When source-ref is provided to this action, it will attempt to initialize
 # the working repository itself, thus not requiring something like actions/checkout
-if ! git status 2>/dev/null; then
-    if [ -z "$SOURCE_REF" ]; then
-        echo "Must provide source-ref without pre-fetched repository"
-        exit 1
-    fi
+if ! git status >/dev/null 2>&1; then
+    [ "$CI" ] || die "Not a git repository!"
+    [ "$ref" ] || die "Must provide source-ref without pre-fetched repository"
     echo "Initializing repository..."
     git init -q "$PWD"
     git remote add origin "https://github.com/$GITHUB_REPOSITORY"
 fi
-if [ "$SOURCE_REF" != "HEAD" ]; then
-    git checkout -q $SOURCE_REF 2>/dev/null || \
-        git fetch origin --depth=$FETCH_DEPTH $SOURCE_REF
-    git checkout -q $SOURCE_REF 2>/dev/null || \
-        git fetch origin --depth=$FETCH_DEPTH refs/tags/$SOURCE_REF:refs/tags/$SOURCE_REF
-    git checkout -q $SOURCE_REF
+
+if [ "$CI" ]; then
+    if [ "$ref" != "HEAD" ]; then
+        git rev-parse -q --no-revs --verify "origin/$ref" || git fetch origin --depth=1 "$ref"
+        git rev-parse -q --no-revs --verify "origin/$ref" || git fetch origin --depth=1 tag "$ref"
+    fi
+    # Ensure that the source revision has some history (actions/checkout also uses depth=1)
+    ref=$(git rev-parse -q --verify "origin/$ref" || git rev-parse -q --verify "$ref")
+    git fetch -q "--depth=$FETCH_DEPTH" origin "+${ref}"
 fi
 
 [ -z "$CLANG_VERSION" ] || set-clang-version "$CLANG_VERSION"
-check-format.sh "$@"
+check-format.sh "$target" "$ref" "$@"

--- a/set-clang-version
+++ b/set-clang-version
@@ -6,7 +6,7 @@ ver="$1"
 clang_format_bin="/usr/local/bin/clang-format-${ver}_linux-amd64"
 [ -f "$clang_format_bin" ] || { echo "Error: File $clang_format_bin not found" >&2; exit 1; }
 
-ln -sf "$clang_format_bin" /usr/bin/clang-format
+ln -sf "$clang_format_bin" /usr/local/bin/clang-format
 
 ver="${ver%%.*}"
 if [ $ver -le 8 ]; then
@@ -17,4 +17,4 @@ else
     git_cf_ver=13
 fi
 
-ln -sf "/usr/local/bin/git-clang-format-${git_cf_ver}" /usr/bin/git-clang-format
+ln -sf "/usr/local/bin/git-clang-format-${git_cf_ver}" /usr/local/bin/git-clang-format


### PR DESCRIPTION
The new `clang-format-checker` script wraps around a docker call to the container, allowing to run it locally.
The desired version of clang-format can be set with an optional `-v<VER>` tag (without a space).

To make this usable interactively and with a provided source-ref different than `HEAD`, #8 had to be fixed. The entrypoint no longer perfoms a `git checkout` and `check-format.sh` respects a second argument as source-ref. Fetch attempts are only made in CI.

Also the script now runs as regular user inside of the container (build-time uid in GH Actions or current uid when called from `clang-format-checker`).