### PR TITLE
Use GITHUB_REF_NAME as source-ref without repository

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -5,25 +5,52 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
-env:
-  DOCKER_BUILDKIT: 1
-
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
       - name: Pull repository
         uses: actions/checkout@v3
-      - name: Build the image
-        run: docker build . --build-arg UID=$(id -u) --tag wolletd/clang-format:latest
-      - name: Build the rooted image
-        run: docker build . --target root --build-arg UID=$(id -u) --tag wolletd/clang-format:root
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Push the image
-        run: docker push wolletd/clang-format:latest
-      - name: Push the rooted image
-        run: docker push wolletd/clang-format:root
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retrieve user ID
+        run: echo "UID=$(id -u)" | tee -a $GITHUB_ENV
+
+      - name: Build and push image with UID
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          build-args: UID=${{ env.UID }}
+          push: true
+          provenance: false
+          tags: |
+            ghcr.io/wolletd/clang-format:latest
+            wolletd/clang-format:latest
+
+      - name: Build and push image with root
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          target: root
+          push: true
+          provenance: false
+          tags: |
+            ghcr.io/wolletd/clang-format:root
+            wolletd/clang-format:root

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,28 +23,36 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+        with:
+          path: .test
       - name: Build the image
-        run: docker build . --build-arg UID=$(id -u) --tag wolletd/clang-format:latest
+        run: docker build .test --build-arg UID=$(id -u) --tag wolletd/clang-format:latest
       - name: test with no error
-        uses: ./
+        uses: ./.test/
         with:
           source-ref: ${{ matrix.src-ok }}
           target-ref: ${{ matrix.target }}
+      - name: clear git repo
+        run: rm -rf .git
       - name: test json is skipped
-        uses: ./
+        uses: ./.test/
         with:
           source-ref: ${{ matrix.src-ok }}
           target-ref: ${{ matrix.target }}
           clang-version: 12
+      - name: clear git repo
+        run: rm -rf .git
       - name: test with format error
-        uses: ./
+        uses: ./.test/
         with:
           source-ref: ${{ matrix.src-err }}
           target-ref: ${{ matrix.target }}
         continue-on-error: true
         id: fail1
+      - name: clear git repo
+        run: rm -rf .git
       - name: test with git error
-        uses: ./
+        uses: ./.test/
         with:
           source-ref: ${{ matrix.src-ok }}
           target-ref: nonexistent

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,12 @@ jobs:
           clang-version: 12
       - name: clear git repo
         run: rm -rf .git
+      - name: test without source-ref (does nothing in this case, but should succeed)
+        uses: ./.test/
+        with:
+          target-ref: ${{ matrix.target }}
+      - name: clear git repo
+        run: rm -rf .git
       - name: test with format error
         uses: ./.test/
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           path: .test
       - name: Build the image
-        run: docker build .test --build-arg UID=$(id -u) --tag wolletd/clang-format:latest
+        run: docker build .test --build-arg UID=$(id -u) --tag ghcr.io/wolletd/clang-format:latest
       - name: test with no error
         uses: ./.test/
         with:
@@ -90,7 +90,7 @@ jobs:
         with:
           path: .test
       - name: Build the image
-        run: docker build .test --build-arg UID=$(id -u) --tag wolletd/clang-format:latest
+        run: docker build .test --build-arg UID=$(id -u) --tag ghcr.io/wolletd/clang-format:latest
       - name: test with no error
         uses: ./.test/
         with:
@@ -126,7 +126,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: Build the image
-        run: docker build . --build-arg UID=$(id -u) --tag wolletd/clang-format:latest
+        run: docker build . --build-arg UID=$(id -u) --tag ghcr.io/wolletd/clang-format:latest
       - name: fetch required refs
         run: git fetch --depth=50 origin master:test tag testdata tag testdata2
       - name: test with no error

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ jobs:
           target-ref: main      # required, merge target
           clang-version: 10     # optional, default: latest (in image)
           fetch-depth: 80       # optional, rarely needed, default: 50
-          source-ref: develop   # optional, almost never needed, default: HEAD
+          source-ref: develop   # optional, almost never needed, default: HEAD if
+                                # a repository exists, $GITHUB_REF_NAME otherwise
 ```
 
 ### Local

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: "docker://wolletd/clang-format:latest"
+  image: "docker://ghcr.io/wolletd/clang-format:latest"
   env:
     FETCH_DEPTH: ${{ inputs.fetch-depth }}
     CLANG_VERSION: ${{ inputs.clang-version }}

--- a/clang-format-checker
+++ b/clang-format-checker
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 thisDir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-docker_image="${CFC_DOCKER_IMAGE:-wolletd/clang-format:latest}"
+docker_image="${CFC_DOCKER_IMAGE:-ghcr.io/wolletd/clang-format:latest}"
 
 die() { echo "$@" >&2; exit 1; }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ fi
 # the working repository itself, thus not requiring something like actions/checkout
 if ! git status >/dev/null 2>&1; then
     [ "$CI" ] || die "Not a git repository!"
-    [ "$ref" ] || die "Must provide source-ref without pre-fetched repository"
+    [ "$ref" = "HEAD" ] && ref=$GITHUB_REF_NAME
     echo "Initializing repository..."
     git init -q "$PWD"
     git remote add origin "https://github.com/$GITHUB_REPOSITORY"


### PR DESCRIPTION
Also:
* update the dockerimage workflow to use the build-push-action
* fix the tests without repository to actually run without repository
* also push images to ghcr.io and use that by default

Closes #15 