### PR TITLE
Build the image without user and use setpriv

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -30,27 +30,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Retrieve user ID
-        run: echo "UID=$(id -u)" | tee -a $GITHUB_ENV
-
-      - name: Build and push image with UID
+      - name: Build and push image
         uses: docker/build-push-action@v4
         with:
           context: .
-          build-args: UID=${{ env.UID }}
           push: true
           provenance: false
           tags: |
             ghcr.io/wolletd/clang-format:latest
             wolletd/clang-format:latest
-
-      - name: Build and push image with root
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          target: root
-          push: true
-          provenance: false
-          tags: |
-            ghcr.io/wolletd/clang-format:root
-            wolletd/clang-format:root

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           path: .test
       - name: Build the image
-        run: docker build .test --build-arg UID=$(id -u) --tag ghcr.io/wolletd/clang-format:latest
+        run: docker build .test --tag ghcr.io/wolletd/clang-format:latest
       - name: test with no error
         uses: ./.test/
         with:
@@ -90,7 +90,7 @@ jobs:
         with:
           path: .test
       - name: Build the image
-        run: docker build .test --build-arg UID=$(id -u) --tag ghcr.io/wolletd/clang-format:latest
+        run: docker build .test --tag ghcr.io/wolletd/clang-format:latest
       - name: test with no error
         uses: ./.test/
         with:
@@ -126,7 +126,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: Build the image
-        run: docker build . --build-arg UID=$(id -u) --tag ghcr.io/wolletd/clang-format:latest
+        run: docker build . --tag ghcr.io/wolletd/clang-format:latest
       - name: fetch required refs
         run: git fetch --depth=50 origin master:test tag testdata tag testdata2
       - name: test with no error

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:latest AS root
+FROM alpine:latest
 
-RUN apk --no-cache add git python3 patch
+RUN apk --no-cache add git python3 patch setpriv
 
 ARG GH_REPO="muttleyxd/clang-tools-static-binaries"
 ARG GH_RELEASE="master-1d7ec53d"
@@ -35,15 +35,8 @@ RUN cd /usr/local/bin && \
     patch -o git-clang-format-8 git-clang-format-${CLANG_LATEST} <0001-remove-json-csharp-support.patch && \
     chmod +rx git-clang-format-12 git-clang-format-8
 
-# GH Actions uses uid 1001 at the time of this writing, but the workflow
-# building this image will set it to the uid used to build
-ARG UID=1001
-
 RUN cd /usr/local/bin && sha512sum -c clang-format_linux.sha512sums && \
     chmod +x /usr/local/bin/clang-format-* && set-clang-version ${CLANG_LATEST} && \
-    chmod go+w /usr/local/bin && adduser -Du "$UID" user
+    chmod go+w /usr/local/bin
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-
-FROM root AS user
-USER user


### PR DESCRIPTION
The issue to solve is, that CI may run as unprivileged user, as it does in GitHub Actions, and we don't want to write files as root that the user can't access.

With this change, we don't set the UID on build time anymore, but rather check the ownership of a .git directory or, if that doesn't exist, the working directory. This makes the image more portable and the custom root image obsolete.