### PR TITLE
Checkout repository if not present

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           source-ref: ${{ matrix.src-ok }}
           target-ref: ${{ matrix.target }}
       - name: clear git repo
-        run: rm -rf .git
+        run: git rm -rf . && rm -rf .git
       - name: test json is skipped
         uses: ./.test/
         with:
@@ -41,13 +41,13 @@ jobs:
           target-ref: ${{ matrix.target }}
           clang-version: 12
       - name: clear git repo
-        run: rm -rf .git
+        run: git rm -rf . && rm -rf .git
       - name: test without source-ref (does nothing in this case, but should succeed)
         uses: ./.test/
         with:
           target-ref: ${{ matrix.target }}
       - name: clear git repo
-        run: rm -rf .git
+        run: git rm -rf . && rm -rf .git
       - name: test with format error
         uses: ./.test/
         with:
@@ -56,7 +56,7 @@ jobs:
         continue-on-error: true
         id: fail1
       - name: clear git repo
-        run: rm -rf .git
+        run: git rm -rf . && rm -rf .git
       - name: test with git error
         uses: ./.test/
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,12 +128,12 @@ jobs:
       - name: Build the image
         run: docker build . --tag ghcr.io/wolletd/clang-format:latest
       - name: fetch required refs
-        run: git fetch --depth=50 origin master:test tag testdata tag testdata2
+        run: git fetch --depth=50 origin master:target tag testdata tag testdata2
       - name: test with no error
-        run: ./clang-format-checker test testdata
+        run: ./clang-format-checker target testdata
       - name: test json is skipped
-        run: ./clang-format-checker -v12 test testdata
+        run: ./clang-format-checker -v12 target testdata
       - name: test with git error
         run: '! ./clang-format-checker nonexistent testdata'
       - name: test with format error
-        run: '! ./clang-format-checker test testdata2'
+        run: '! ./clang-format-checker target testdata2'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,6 +30,7 @@ fi
 if ! git status >/dev/null 2>&1; then
     [ "$CI" ] || die "Not a git repository!"
     [ "$ref" = "HEAD" ] && ref=$GITHUB_REF_NAME
+    checkout=1
     echo "Initializing repository..."
     git init -q "$PWD"
     git remote add origin "https://github.com/$GITHUB_REPOSITORY"
@@ -47,6 +48,7 @@ if [ "$CI" ]; then
     # Ensure that the source revision has some history (actions/checkout also uses depth=1)
     ref=$(git rev-parse -q --verify "origin/$ref" || git rev-parse -q --verify "$ref")
     git fetch -q "--depth=$FETCH_DEPTH" origin "+${ref}"
+    [ "$checkout" ] && git checkout "$ref"
 fi
 
 [ -z "$CLANG_VERSION" ] || set-clang-version "$CLANG_VERSION"


### PR DESCRIPTION
To use the `.clang-format` configuration of the project. Also update tests to check this.

Closes #19.