### PR TITLE
Don't call filter_ignored_files prior to clang-format 19

### DIFF
--- a/0001-remove-list-ignored-support.patch
+++ b/0001-remove-list-ignored-support.patch
@@ -1,0 +1,10 @@
+--- a/git-clang-format-19
++++ b/git-clang-format-19
+@@ -173,7 +173,6 @@
+   # those files.
+   cd_to_toplevel()
+   filter_symlinks(changed_lines)
+-  filter_ignored_files(changed_lines, binary=opts.binary)
+   if opts.verbose >= 1:
+     ignored_files.difference_update(changed_lines)
+     if ignored_files:

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,16 +30,18 @@ ADD ${GH_URL}/clang-format-3.9_linux-amd64  \
     set-clang-version                       \
     clang-format_linux.sha512sums           \
     git-clang-format-${CLANG_LATEST}        \
+    0001-remove-list-ignored-support.patch  \
     0001-remove-verilog-support.patch       \
     0001-remove-json-support.patch          \
     0001-remove-csharp-support.patch        \
     /usr/local/bin/
 
 RUN cd /usr/local/bin && \
-    patch -o git-clang-format-17 git-clang-format-${CLANG_LATEST} <0001-remove-verilog-support.patch && \
+    patch -o git-clang-format-18 git-clang-format-${CLANG_LATEST} <0001-remove-list-ignored-support.patch && \
+    patch -o git-clang-format-17 git-clang-format-18 <0001-remove-verilog-support.patch && \
     patch -o git-clang-format-12 git-clang-format-17 <0001-remove-json-support.patch && \
     patch -o git-clang-format-8 git-clang-format-12 <0001-remove-csharp-support.patch && \
-    chmod +rx git-clang-format-17 git-clang-format-12 git-clang-format-8
+    chmod +rx git-clang-format-18 git-clang-format-17 git-clang-format-12 git-clang-format-8
 
 RUN cd /usr/local/bin && sha512sum -c clang-format_linux.sha512sums && \
     chmod +x /usr/local/bin/clang-format-* && set-clang-version ${CLANG_LATEST} && \

--- a/set-clang-version
+++ b/set-clang-version
@@ -13,6 +13,8 @@ if [ $ver -le 8 ]; then
     git_cf_ver=8
 elif [ $ver -le 12 ]; then
     git_cf_ver=12
+elif [ $ver -le 18 ]; then
+    git_cf_ver=18
 else
     git_cf_ver=${CLANG_LATEST}
 fi


### PR DESCRIPTION
This removes the call to `filter_ignored_files` for clang-format before version 19, preventing `clang-format` from being called with the unsupported parameter `-list-ignored`.

Fixes #23 